### PR TITLE
Plan 9 uses syscall.Waitmsg instead of syscall.WaitStatus

### DIFF
--- a/exec_plan9.go
+++ b/exec_plan9.go
@@ -1,0 +1,18 @@
+// +build plan9
+
+package wrapcommander
+
+import (
+	"os"
+	"strings"
+)
+
+var badExec = "exec header invalid"
+
+// IsExecFormatError returns a boolean indicating whether the error is known to
+// report that format of an executable file is invalid.
+// ex. "fork/exec ./prog: exec format error"
+func IsExecFormatError(err error) bool {
+	e, ok := err.(*os.PathError)
+	return ok && strings.Contains(e.Error(), badExec)
+}

--- a/exec_plan9.go
+++ b/exec_plan9.go
@@ -7,12 +7,19 @@ import (
 	"strings"
 )
 
-var badExec = "exec header invalid"
+var (
+	badExec = "exec header invalid"
+	dirExec = "cannot exec directory"
+)
 
 // IsExecFormatError returns a boolean indicating whether the error is known to
 // report that format of an executable file is invalid.
 // ex. "fork/exec ./prog: exec format error"
 func IsExecFormatError(err error) bool {
 	e, ok := err.(*os.PathError)
-	return ok && strings.Contains(e.Error(), badExec)
+	if !ok {
+		return false
+	}
+	return strings.HasSuffix(e.Error(), badExec) ||
+		strings.HasSuffix(e.Error(), dirExec)
 }

--- a/exec_posix.go
+++ b/exec_posix.go
@@ -1,0 +1,16 @@
+// +build !plan9
+
+package wrapcommander
+
+import (
+	"os"
+	"syscall"
+)
+
+// IsExecFormatError returns a boolean indicating whether the error is known to
+// report that format of an executable file is invalid.
+// ex. "fork/exec ./prog: exec format error"
+func IsExecFormatError(err error) bool {
+	e, ok := err.(*os.PathError)
+	return ok && e.Err == syscall.ENOEXEC
+}

--- a/exitstatus.go
+++ b/exitstatus.go
@@ -3,7 +3,6 @@ package wrapcommander
 import (
 	"os"
 	"os/exec"
-	"syscall"
 )
 
 // ExitStatus represents command exit status information
@@ -12,7 +11,7 @@ type ExitStatus struct {
 
 	exitCode          int
 	signaled, invoked bool
-	signal            syscall.Signal
+	signal            Signal
 }
 
 // Err returns original error
@@ -36,7 +35,7 @@ func (es *ExitStatus) Invoked() bool {
 }
 
 // Signal returns a received signal
-func (es *ExitStatus) Signal() syscall.Signal {
+func (es *ExitStatus) Signal() Signal {
 	return es.signal
 }
 
@@ -66,12 +65,11 @@ func ResolveExitStatus(err error) *ExitStatus {
 		return es
 	}
 
-	w, ok := eerr.Sys().(syscall.WaitStatus)
+	w, ok := eerr.Sys().(WaitStatus)
 	if !ok {
 		return es
 	}
-	es.signaled = w.Signaled()
-	es.signal = w.Signal()
+	es.signaled, es.signal = detectSignal(w)
 	es.exitCode = waitStatusToExitCode(w)
 
 	return es

--- a/exitstatus_plan9.go
+++ b/exitstatus_plan9.go
@@ -4,6 +4,7 @@ package wrapcommander
 
 import "strings"
 
+// Signal represents POSIX signal.
 type Signal int
 
 // These numbers are imported from /sys/include/ape/signal.h

--- a/exitstatus_plan9.go
+++ b/exitstatus_plan9.go
@@ -1,0 +1,61 @@
+// +build plan9
+
+package wrapcommander
+
+import "strings"
+
+type Signal int
+
+const (
+	// see /sys/include/ape/signal.h
+	SIGHUP  Signal = 1
+	SIGINT         = 2
+	SIGQUIT        = 3
+	SIGILL         = 4
+	SIGABRT        = 5
+	SIGFPE         = 6
+	SIGKILL        = 7
+	SIGSEGV        = 8
+	SIGPIPE        = 9
+	SIGALRM        = 10
+	SIGTERM        = 11
+	SIGUSR1        = 12
+	SIGUSR2        = 13
+)
+
+var sigtab = []struct {
+	Msg string
+	Sig Signal
+}{
+	{"hangup", SIGHUP},
+	{"interrupt", SIGINT},
+	{"quit", SIGQUIT},
+	{"alarm", SIGALRM},
+	{"sys: trap: illegal instruction", SIGILL},
+	{"sys: trap: reserved instruction", SIGILL},
+	{"sys: trap: reserved", SIGILL},
+	{"sys: trap: arithmetic overflow", SIGFPE},
+	{"abort", SIGABRT},
+	{"sys: fp:", SIGFPE},
+	{"exit", SIGKILL},
+	{"die", SIGKILL},
+	{"kill", SIGKILL},
+	{"sys: trap: bus error", SIGSEGV},
+	{"sys: trap: address error", SIGSEGV},
+	{"sys: trap: TLB", SIGSEGV},
+	{"sys: write on closed pipe", SIGPIPE},
+	{"alarm", SIGALRM},
+	{"term", SIGTERM},
+	{"usr1", SIGUSR1},
+	{"usr2", SIGUSR2},
+}
+
+func detectSignal(w WaitStatus) (signaled bool, signal Signal) {
+	for _, sig := range sigtab {
+		if strings.HasPrefix(w.Msg, sig.Msg) {
+			signaled = true
+			signal = sig.Sig
+		}
+	}
+	return
+}

--- a/exitstatus_posix.go
+++ b/exitstatus_posix.go
@@ -4,6 +4,7 @@ package wrapcommander
 
 import "syscall"
 
+// Signal represents POSIX signal.
 type Signal = syscall.Signal
 
 func detectSignal(w WaitStatus) (signaled bool, signal Signal) {

--- a/exitstatus_posix.go
+++ b/exitstatus_posix.go
@@ -1,0 +1,13 @@
+// +build !plan9
+
+package wrapcommander
+
+import "syscall"
+
+type Signal = syscall.Signal
+
+func detectSignal(w WaitStatus) (signaled bool, signal Signal) {
+	signaled = w.Signaled()
+	signal = w.Signal()
+	return
+}

--- a/exitstatus_test.go
+++ b/exitstatus_test.go
@@ -8,6 +8,16 @@ import (
 )
 
 func TestResolveExitStatus(t *testing.T) {
+	var ext string
+	switch runtime.GOOS {
+	case "windows":
+		t.Skip("not supported on windows")
+	case "plan9":
+		ext = ".rc"
+	default:
+		ext = ".sh"
+	}
+
 	var testCases = []struct {
 		cmd  string
 		want int
@@ -17,13 +27,10 @@ func TestResolveExitStatus(t *testing.T) {
 		{"./gogogo-dummy", ExitCommandNotFound},
 		{"./testdata/dir", ExitCommandNotInvoked},
 		{"./testdata/execformaterror", ExitCommandNotInvoked},
-		{"./testdata/echo.sh", 0},
-		{"./testdata/exit1.sh", 1},
+		{"./testdata/echo" + ext, 0},
+		{"./testdata/exit1" + ext, 1},
 	}
 
-	if runtime.GOOS == "windows" {
-		t.Skip("not supported on windows")
-	}
 	for _, tt := range testCases {
 		err := exec.Command(tt.cmd).Run()
 		es := ResolveExitStatus(err)

--- a/testdata/echo.rc
+++ b/testdata/echo.rc
@@ -1,0 +1,2 @@
+#!/bin/rc
+echo 1

--- a/testdata/exit1.rc
+++ b/testdata/exit1.rc
@@ -1,0 +1,2 @@
+#!/bin/rc
+exit 1

--- a/waitstatus_notunix.go
+++ b/waitstatus_notunix.go
@@ -1,9 +1,0 @@
-// +build plan9 windows
-
-package wrapcommander
-
-import "syscall"
-
-func waitStatusToExitCode(w syscall.WaitStatus) int {
-	return w.ExitStatus()
-}

--- a/waitstatus_plan9.go
+++ b/waitstatus_plan9.go
@@ -2,10 +2,52 @@
 
 package wrapcommander
 
-import "syscall"
+import (
+	"strconv"
+	"strings"
+	"syscall"
+)
 
-type WaitStatus = syscall.Waitmsg
+type WaitStatus = *syscall.Waitmsg
+
+/*
+ * Plan 9 uses error string instead of exit code.
+ * For example, errstr contains 'go: interrupt'
+ * when process is catched a interrupt. (aka SIGINT)
+ *
+ * However, programs that is written for ANSI/POSIX still uses exit code.
+ * In this case, errstr contains a number, like 'go: 2'
+ */
+
+const signalBase = 128
 
 func waitStatusToExitCode(w WaitStatus) int {
-	return w.ExitStatus()
+	msg := causeMsg(w.Msg)
+	if msg == "" {
+		return 0
+	}
+
+	if sig := lookupSignal(msg); sig != 0 {
+		return signalBase + int(sig)
+	}
+	n, err := strconv.Atoi(msg)
+	if err != nil {
+		return 1
+	}
+	return n
+}
+
+func causeMsg(msg string) string {
+	i := strings.LastIndex(msg, ":")
+	if i < 0 {
+		return msg
+	}
+	s := strings.TrimSpace(msg[i+1:])
+	if n := len(s); n > 0 && s[n-1] == '\'' {
+		s = s[:n-1]
+	}
+	if s == "" {
+		return msg
+	}
+	return s
 }

--- a/waitstatus_plan9.go
+++ b/waitstatus_plan9.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 )
 
+// WaitStatus represents exit status of a process.
 type WaitStatus = *syscall.Waitmsg
 
 /*

--- a/waitstatus_plan9.go
+++ b/waitstatus_plan9.go
@@ -1,0 +1,11 @@
+// +build plan9
+
+package wrapcommander
+
+import "syscall"
+
+type WaitStatus = syscall.Waitmsg
+
+func waitStatusToExitCode(w WaitStatus) int {
+	return w.ExitStatus()
+}

--- a/waitstatus_unix.go
+++ b/waitstatus_unix.go
@@ -4,6 +4,7 @@ package wrapcommander
 
 import "syscall"
 
+// WaitStatus represents exit status of a process.
 type WaitStatus = syscall.WaitStatus
 
 func waitStatusToExitCode(w WaitStatus) int {

--- a/waitstatus_windows.go
+++ b/waitstatus_windows.go
@@ -1,4 +1,4 @@
-// +build !plan9,!windows
+// +build windows
 
 package wrapcommander
 
@@ -7,8 +7,5 @@ import "syscall"
 type WaitStatus = syscall.WaitStatus
 
 func waitStatusToExitCode(w WaitStatus) int {
-	if w.Signaled() {
-		return int(w.Signal()) + 128
-	}
 	return w.ExitStatus()
 }

--- a/waitstatus_windows.go
+++ b/waitstatus_windows.go
@@ -4,6 +4,7 @@ package wrapcommander
 
 import "syscall"
 
+// WaitStatus represents exit status of a process.
 type WaitStatus = syscall.WaitStatus
 
 func waitStatusToExitCode(w WaitStatus) int {

--- a/wrapcommander.go
+++ b/wrapcommander.go
@@ -3,7 +3,6 @@ package wrapcommander
 import (
 	"os"
 	"os/exec"
-	"syscall"
 )
 
 // exit statuses are same with GNU coreutils
@@ -32,14 +31,6 @@ func IsNotFoundInPATH(err error) bool {
 	return ok && e.Err == exec.ErrNotFound
 }
 
-// IsExecFormatError returns a boolean indicating whether the error is known to
-// report that format of an executable file is invalid.
-// ex. "fork/exec ./prog: exec format error"
-func IsExecFormatError(err error) bool {
-	e, ok := err.(*os.PathError)
-	return ok && e.Err == syscall.ENOEXEC
-}
-
 // IsInvoked returns a boolean indicating whether the error is known to report
 // that the command is invoked or not.
 func IsInvoked(err error) bool {
@@ -50,18 +41,18 @@ func IsInvoked(err error) bool {
 	return ok
 }
 
-// ErrorToWaitStatus try to convert error into syscall.WaitStatus
-func ErrorToWaitStatus(err error) (syscall.WaitStatus, bool) {
+// ErrorToWaitStatus try to convert error into WaitStatus
+func ErrorToWaitStatus(err error) (WaitStatus, bool) {
 	if e, ok := err.(*exec.ExitError); ok {
-		st, ok := e.Sys().(syscall.WaitStatus)
+		st, ok := e.Sys().(WaitStatus)
 		return st, ok
 	}
-	var zero syscall.WaitStatus
+	var zero WaitStatus
 	return zero, false
 }
 
 // WaitStatusToExitCode converts WaitStatus to ExitCode
-func WaitStatusToExitCode(st syscall.WaitStatus) int {
+func WaitStatusToExitCode(st WaitStatus) int {
 	return waitStatusToExitCode(st)
 }
 

--- a/wrapcommander_test.go
+++ b/wrapcommander_test.go
@@ -50,20 +50,24 @@ func TestIsNotFoundInPATH(t *testing.T) {
 	}
 }
 
-var isExecFormatErrorTests = []testCmd{
-	{"go", false},
-	{"gogogo-dummy", false},
-	{"./testdata/dir", false},
-	{"./testdata/echo.sh", false},
-	{"./testdata/execformaterror", true},
-}
-
 func TestIsExecFormatErrorTests(t *testing.T) {
+	var ext string
+	switch runtime.GOOS {
+	case "windows":
+		t.Skip("not supported on windows")
+	case "plan9":
+		ext = ".rc"
+	default:
+		ext = ".sh"
+	}
+	var isExecFormatErrorTests = []testCmd{
+		{"go", false},
+		{"gogogo-dummy", false},
+		{"./testdata/dir", false},
+		{"./testdata/echo" + ext, false},
+		{"./testdata/execformaterror", true},
+	}
 	for _, tt := range isExecFormatErrorTests {
-		if runtime.GOOS == "windows" {
-			t.Log("not supported on windows")
-			continue
-		}
 		err := exec.Command(tt.cmd).Run()
 		if got := IsExecFormatError(err); got != tt.want {
 			t.Errorf("IsExecFormatError(exec.Command(%#v).Run()) = %v; want %v", tt.cmd, got, tt.want)
@@ -74,23 +78,29 @@ func TestIsExecFormatErrorTests(t *testing.T) {
 	}
 }
 
-var resolveExitCodeTests = []struct {
-	cmd  string
-	want int
-}{
-	{"go", 2},
-	{"gogogo-dummy", ExitCommandNotFound},
-	{"./gogogo-dummy", ExitCommandNotFound},
-	{"./testdata/dir", ExitCommandNotInvoked},
-	{"./testdata/execformaterror", ExitCommandNotInvoked},
-	{"./testdata/echo.sh", 0},
-	{"./testdata/exit1.sh", 1},
-}
-
 func TestResolveExitCode(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	var ext string
+	switch runtime.GOOS {
+	case "windows":
 		t.Skip("not supported on windows")
+	case "plan9":
+		ext = ".rc"
+	default:
+		ext = ".sh"
 	}
+	var resolveExitCodeTests = []struct {
+		cmd  string
+		want int
+	}{
+		{"go", 2},
+		{"gogogo-dummy", ExitCommandNotFound},
+		{"./gogogo-dummy", ExitCommandNotFound},
+		{"./testdata/dir", ExitCommandNotInvoked},
+		{"./testdata/execformaterror", ExitCommandNotInvoked},
+		{"./testdata/echo" + ext, 0},
+		{"./testdata/exit1" + ext, 1},
+	}
+
 	for _, tt := range resolveExitCodeTests {
 		err := exec.Command(tt.cmd).Run()
 		got := ResolveExitCode(err)

--- a/wrapcommander_test.go
+++ b/wrapcommander_test.go
@@ -21,8 +21,8 @@ var isPermissionTests = []testCmd{
 }
 
 func TestIsPermission(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("not supported on windows")
+	if runtime.GOOS == "windows" || runtime.GOOS == "plan9" {
+		t.Skip("not supported on windows or plan9")
 	}
 	for _, tt := range isPermissionTests {
 		err := exec.Command(tt.cmd).Run()

--- a/wrapcommander_test.go
+++ b/wrapcommander_test.go
@@ -68,6 +68,10 @@ func TestIsExecFormatErrorTests(t *testing.T) {
 		{"./testdata/execformaterror", true},
 	}
 	for _, tt := range isExecFormatErrorTests {
+		if runtime.GOOS == "plan9" && tt.cmd == "./testdata/dir" {
+			t.Logf("%s: not supported on plan9", tt.cmd)
+			continue
+		}
 		err := exec.Command(tt.cmd).Run()
 		if got := IsExecFormatError(err); got != tt.want {
 			t.Errorf("IsExecFormatError(exec.Command(%#v).Run()) = %v; want %v", tt.cmd, got, tt.want)


### PR DESCRIPTION
## motivation

I want to build *wrapcommander* to Plan 9 operating system.
Plan 9 uses `syscall.Waitmsg` instead of `syscall.WaitStatus`, and uses error string instead of exit code.

## discussion

This PR changes `syscall.WaitStatus` type to `WaitStatus` type that is alias of `syscall.WaitStatus`.
I have examined that this changes don't break barckward compatibility if Go 1.9 or later.
Go 1.8.x or earlier can't build.